### PR TITLE
Add reportMode functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 jest-output.json
 .env
 *-jest-output.json
+package-lock.json

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,8 @@ You will have a `testOptions.json` file in the root of this project, you should 
 | name                  | Description                                                                                                                                         | Default Value          | Required |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | -------- |
 | files                 | The files or directory that you want to test, setting it to an empty array will test all files                                                      | []                     | false    |
-| customColumns         | The name of the columns that will be related to the directory structure                                                                             | []                     | true     |
+| reportMode            | Change the type of report keeping its default structure or adjusting the report columns                                                             | staticDeep             | true     |
+| columnNames           | The name of the columns that will be related to the directory structure                                                                             | []                     | true     |
 | virtualUserSuites     | The number of whole test suites you want to simulate and its specific configurations and variables, each test virtual user suite represents 1 user. | virtualUserSuite array | true     |
 | virtualUserMultiplier | If you want to execute more users. It multiplies the virtualUserSuites.                                                                             | 1                      | false    |
 
@@ -73,7 +74,8 @@ A `virtualUserSuite` object has the following properties:
 {
   "files": [],
   "virtualUserMultiplier": 1,
-  "customColumns": ["enterprise", "department", "feature", "scenario"],
+  "reportMode": "staticDeep",
+  "columnNames": ["enterprise", "department", "feature", "scenario"],
   "virtualUserSuites": [
     {
       "skip": false,
@@ -113,7 +115,8 @@ Example in `testOptions.json` file
 {
   "files": [],
   "virtualUserMultiplier": 1,
-  "customColumns": ["enterprise", "department", "feature", "scenario"],
+  "reportMode": "staticDeep",
+  "columnNames": ["enterprise", "department", "feature", "scenario"],
   "virtualUserSuites": [
     {
       "skip": false,
@@ -151,7 +154,8 @@ Example in `testOptions.json` file
 {
   "files": [],
   "virtualUserMultiplier": 1,
-  "customColumns": ["enterprise", "department", "feature", "scenario"],
+  "reportMode": "staticDeep",
+  "columnNames": ["enterprise", "department", "feature", "scenario"],
   "virtualUserSuites": [
     {
       "skip": false,
@@ -209,9 +213,11 @@ In the `testOptions.json` file:
 
 ```json
 {
-  "customColumns": ["enterprise", "department", "feature", "scenario"]
+  "columnNames": ["enterprise", "department", "feature", "scenario"]
 }
 ```
+
+For an advanced configuration of the type of report visit [Report mode](https://github.com/usil/selenium-nodejs-starter/wiki/Setting#report-mode)
 
 Then just create your tests using traditional jest and selenium. After that run:
 

--- a/src/helpers/sortTestResults.js
+++ b/src/helpers/sortTestResults.js
@@ -1,0 +1,35 @@
+const os = require("os");
+
+/**
+ * 
+ * @param {array} results Test results
+ * @returns {object}
+ */
+const sortTestResults = (results) => {
+
+  // Get the result object
+  let object = results.slice(0);
+
+  // Define the type of separator according to the system
+  let osSplit = os.type() === "Windows_NT" ? "\\" : "/";
+
+  // Get the results in alphabetical order at the first level
+  object.sort((firstElement, secondElement) => {
+    let first = firstElement.name.split(osSplit)
+    let second = secondElement.name.split(osSplit)
+
+    const testsIndex = first.indexOf('tests')
+
+    first = first.slice(testsIndex + 1)
+    second = second.slice(testsIndex + 1)
+
+    first = first[0].toLowerCase()
+    second = second[0].toLowerCase()
+
+    return first < second ? -1 : first > second ? 1 : 0
+  })
+
+  return object
+}
+
+module.exports = sortTestResults

--- a/src/helpers/sortTestResults.js
+++ b/src/helpers/sortTestResults.js
@@ -3,7 +3,7 @@ const os = require("os");
 /**
  * 
  * @param {array} results Test results
- * @returns {object}
+ * @returns {object} Order test results
  */
 const sortTestResults = (results) => {
 

--- a/src/helpers/sortTestResults.js
+++ b/src/helpers/sortTestResults.js
@@ -7,6 +7,10 @@ const os = require("os");
  */
 const sortTestResults = (results) => {
 
+  // Return result if it only has one content
+  if (results.length === 1)
+    return results
+
   // Get the result object
   let object = results.slice(0);
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const os = require("os");
 const { EnvSettings } = require("advanced-settings");
 
 const util = require("util");
+const sortTestResults = require("./helpers/sortTestResults");
 
 const exec = util.promisify(require("child_process").exec);
 
@@ -59,7 +60,9 @@ const createTable = (suiteIdentifier, stderr, virtualUser) => {
 
   let testResultIndex = 0;
 
-  for (const testResult of jestOutput.testResults) {
+  let testResults = sortTestResults(jestOutput.testResults)
+
+  for (const testResult of testResults) {
     const path =
       os.type() === "Windows_NT"
         ? testResult.name.split("\\")

--- a/testOptions.json
+++ b/testOptions.json
@@ -1,7 +1,13 @@
 {
   "files": [],
   "virtualUserMultiplier": 1,
-  "customColumns": ["enterprise", "department", "feature", "scenario"],
+  "reportMode": "staticDeep",
+  "columnNames": [
+    "enterprise",
+    "department",
+    "feature",
+    "scenario"
+  ],
   "virtualUserSuites": [
     {
       "skip": false,


### PR DESCRIPTION
## Functionality 'reportMode'

### Current reporting
When generating reports, the folder depth in `./tests/` refers directly to the columns:

Example:

Test definition :

    .tests
    ├── ...
    ├── enterprise                    # In the example USIL
    │   ├── department                # In the example marketing
    |       ├── feature               # In the example google-seo
    |           ├── scenario1         # In the example shouldAppearFirstFour
    |               ├── scenario1.js  # In the example shouldAppearFirstFour.test.js
    └── ...

Generated report :

| enterprise | department | feature | scenari1 | Status |
| ------------- | ---------------- | --------- | ----------- | --------- |
| usil | marketing | google-seo | shouldApperFirstFour | passed |


### Expected reporting

When making use of the new functionality, the report only consists of 3 defined columns, which refer to the following structure:

| system | functionality | scenario |
| --------- | ---------------- | ----------- |

So for the same example above, the generated report would be the following:

Example :

Test definition :

    .tests
    ├── ...
    ├── enterprise                    # In the example USIL
    │   ├── department                # In the example marketing
    |       ├── feature               # In the example google-seo
    |           ├── scenario1         # In the example shouldAppearFirstFour
    |               ├── scenario1.js  # In the example shouldAppearFirstFour.test.js
    └── ...

Generated report :

| system | functionality | scenario | Status |
| --------- | ---------------- | ----------- | --------- |
| usil | marketing/google-seo | shouldApperFirstFour | passed |